### PR TITLE
[fr] Typo corrected in french translation of Service Worker API page

### DIFF
--- a/files/fr/web/api/service_worker_api/index.md
+++ b/files/fr/web/api/service_worker_api/index.md
@@ -15,7 +15,7 @@ Un <i lang="en">service worker</i> est un [<i lang="en">worker</i>](/fr/docs/Web
 
 Un <i lang="en">service worker</i> s'exécute dans le contexte d'un <i lang="en">worker</i> et n'a donc pas accès au DOM. Il s'exécute dans un <i lang="en">thread</i> différent du <i lang="en">thread</i> JavaScript principal et n'est donc pas bloquant. Il est conçu pour fonctionner de façon complètement asynchrone. Aussi, les API synchrones comme [XHR](/fr/docs/Web/API/XMLHttpRequest) et [<i lang="en">Web Storage</i>](/fr/docs/Web/API/Web_Storage_API) ne peuvent pas être utilisées dans le code d'un <i lang="en">service worker</i>.
 
-Pour des raisons de sécurité, les <i lang="en">service workers</i> ne fonctionnent qu'avec le protocole HTTPS. En effet, les connexions HTTP sont susceptibles d'être victimes d'injection de code par [attaque du monstre du milieu](/fr/docs/Glossary/MitM) et l'accès à ces API aggraverait ces attaques.
+Pour des raisons de sécurité, les <i lang="en">service workers</i> ne fonctionnent qu'avec le protocole HTTPS. En effet, les connexions HTTP sont susceptibles d'être victimes d'injection de code par [attaque de l'homme du milieu](/fr/docs/Glossary/MitM) et l'accès à ces API aggraverait ces attaques.
 
 > **Note :** Sur Firefox, les <i lang="en">service workers</i> ne fonctionnent pas en navigation privée.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Man in the Middle attack (MitM) was translated in french as Monster in the Middle, in the [Service Worker API](https://developer.mozilla.org/fr/docs/Web/API/Service_Worker_API).

You can quickly find the typo by searching « monstre », which means monster in french.

I just corrected this typo

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Helping the community :) !

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://developer.mozilla.org/fr/docs/Glossary/MitM
https://developer.mozilla.org/fr/docs/Web/API/Service_Worker_API

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
